### PR TITLE
Store devices in BLEService

### DIFF
--- a/Friendify.xcodeproj/project.pbxproj
+++ b/Friendify.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		27389C5323DE1873003B7E71 /* DeviceListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27389C5223DE1873003B7E71 /* DeviceListViewModel.swift */; };
+		27389C5523DE34B7003B7E71 /* HomeViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27389C5423DE34B7003B7E71 /* HomeViewModel.swift */; };
 		8897F3F723B4AF20006F014D /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8897F3F623B4AF20006F014D /* AppDelegate.swift */; };
 		8897F3F923B4AF20006F014D /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8897F3F823B4AF20006F014D /* SceneDelegate.swift */; };
 		8897F3FC23B4AF20006F014D /* Friendify.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = 8897F3FA23B4AF20006F014D /* Friendify.xcdatamodeld */; };
@@ -42,6 +44,8 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		27389C5223DE1873003B7E71 /* DeviceListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceListViewModel.swift; sourceTree = "<group>"; };
+		27389C5423DE34B7003B7E71 /* HomeViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeViewModel.swift; sourceTree = "<group>"; };
 		8897F3F323B4AF20006F014D /* Friendify.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Friendify.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		8897F3F623B4AF20006F014D /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		8897F3F823B4AF20006F014D /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -118,9 +122,11 @@
 				8897F3F623B4AF20006F014D /* AppDelegate.swift */,
 				8897F3F823B4AF20006F014D /* SceneDelegate.swift */,
 				8897F43323BE6F47006F014D /* Home.swift */,
+				27389C5423DE34B7003B7E71 /* HomeViewModel.swift */,
 				8897F42923B4B189006F014D /* Device.swift */,
 				8897F42B23B4B302006F014D /* DeviceRow.swift */,
 				8897F42D23B4B3F4006F014D /* DeviceList.swift */,
+				27389C5223DE1873003B7E71 /* DeviceListViewModel.swift */,
 				8897F43123BE6758006F014D /* DeviceDetail.swift */,
 				8897F3FF23B4AF21006F014D /* Assets.xcassets */,
 				8897F40423B4AF21006F014D /* LaunchScreen.storyboard */,
@@ -295,8 +301,10 @@
 				8897F43623CF86E3006F014D /* CBController.swift in Sources */,
 				8897F42C23B4B302006F014D /* DeviceRow.swift in Sources */,
 				8897F42E23B4B3F4006F014D /* DeviceList.swift in Sources */,
+				27389C5523DE34B7003B7E71 /* HomeViewModel.swift in Sources */,
 				8897F43023B4C6D2006F014D /* BLEService.swift in Sources */,
 				8897F3F923B4AF20006F014D /* SceneDelegate.swift in Sources */,
+				27389C5323DE1873003B7E71 /* DeviceListViewModel.swift in Sources */,
 				8897F42A23B4B189006F014D /* Device.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Friendify.xcodeproj/project.pbxproj
+++ b/Friendify.xcodeproj/project.pbxproj
@@ -18,7 +18,7 @@
 		8897F42A23B4B189006F014D /* Device.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8897F42923B4B189006F014D /* Device.swift */; };
 		8897F42C23B4B302006F014D /* DeviceRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8897F42B23B4B302006F014D /* DeviceRow.swift */; };
 		8897F42E23B4B3F4006F014D /* DeviceList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8897F42D23B4B3F4006F014D /* DeviceList.swift */; };
-		8897F43023B4C6D2006F014D /* BLEcontroller.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8897F42F23B4C6D2006F014D /* BLEcontroller.swift */; };
+		8897F43023B4C6D2006F014D /* BLEService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8897F42F23B4C6D2006F014D /* BLEService.swift */; };
 		8897F43223BE6758006F014D /* DeviceDetail.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8897F43123BE6758006F014D /* DeviceDetail.swift */; };
 		8897F43423BE6F47006F014D /* Home.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8897F43323BE6F47006F014D /* Home.swift */; };
 		8897F43623CF86E3006F014D /* CBController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8897F43523CF86E3006F014D /* CBController.swift */; };
@@ -59,7 +59,7 @@
 		8897F42923B4B189006F014D /* Device.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Device.swift; sourceTree = "<group>"; };
 		8897F42B23B4B302006F014D /* DeviceRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceRow.swift; sourceTree = "<group>"; };
 		8897F42D23B4B3F4006F014D /* DeviceList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceList.swift; sourceTree = "<group>"; };
-		8897F42F23B4C6D2006F014D /* BLEcontroller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BLEcontroller.swift; sourceTree = "<group>"; };
+		8897F42F23B4C6D2006F014D /* BLEService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BLEService.swift; sourceTree = "<group>"; };
 		8897F43123BE6758006F014D /* DeviceDetail.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceDetail.swift; sourceTree = "<group>"; };
 		8897F43323BE6F47006F014D /* Home.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Home.swift; sourceTree = "<group>"; };
 		8897F43523CF86E3006F014D /* CBController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CBController.swift; sourceTree = "<group>"; };
@@ -113,7 +113,7 @@
 		8897F3F523B4AF20006F014D /* Friendify */ = {
 			isa = PBXGroup;
 			children = (
-				8897F42F23B4C6D2006F014D /* BLEcontroller.swift */,
+				8897F42F23B4C6D2006F014D /* BLEService.swift */,
 				8897F43523CF86E3006F014D /* CBController.swift */,
 				8897F3F623B4AF20006F014D /* AppDelegate.swift */,
 				8897F3F823B4AF20006F014D /* SceneDelegate.swift */,
@@ -295,7 +295,7 @@
 				8897F43623CF86E3006F014D /* CBController.swift in Sources */,
 				8897F42C23B4B302006F014D /* DeviceRow.swift in Sources */,
 				8897F42E23B4B3F4006F014D /* DeviceList.swift in Sources */,
-				8897F43023B4C6D2006F014D /* BLEcontroller.swift in Sources */,
+				8897F43023B4C6D2006F014D /* BLEService.swift in Sources */,
 				8897F3F923B4AF20006F014D /* SceneDelegate.swift in Sources */,
 				8897F42A23B4B189006F014D /* Device.swift in Sources */,
 			);

--- a/Friendify/BLEService.swift
+++ b/Friendify/BLEService.swift
@@ -11,8 +11,7 @@ import CoreBluetooth
 import SwiftUI
 import Combine
 
-class BLECentralViewController: UIViewController, CBCentralManagerDelegate, CBPeripheralDelegate {
-    
+class BLEService: NSObject, CBCentralManagerDelegate, CBPeripheralDelegate {
     //centralManager = CBCentralManager(delegate: self, queue: nil)
     var centralManager: CBCentralManager!
     var blePeripheral: CBPeripheral!
@@ -22,17 +21,11 @@ class BLECentralViewController: UIViewController, CBCentralManagerDelegate, CBPe
     var RSSIs = [NSNumber]()
     var connectedPeripherals = [CBPeripheral]()
     
-    override func viewDidLoad() {
+    func start() {
         print("Testing")
-        super.viewDidLoad()
         let backgroundQueue = DispatchQueue.global(qos: .background)
         centralManager = CBCentralManager(delegate: self, queue: backgroundQueue)
     }
-    
-    override func didReceiveMemoryWarning() {
-         super.didReceiveMemoryWarning()
-         // Dispose of any resources that can be recreated.
-     }
     
     func centralManagerDidUpdateState(_ central: CBCentralManager) {
         
@@ -45,12 +38,14 @@ class BLECentralViewController: UIViewController, CBCentralManagerDelegate, CBPe
             startScan()
         case .poweredOff:
             print("Bluetooth is OFF")
+            // TODO: Not a good solution, calling back to the view would be better
+            let window = UIApplication.shared.windows.first
             let bluetoothAlert = UIAlertController(title: "Bluetooth is not enabled", message: "Please turn your Bluetooth on", preferredStyle: UIAlertController.Style.alert)
             let bluetoothAction = UIAlertAction(title: "Ok", style: UIAlertAction.Style.default, handler: { (action: UIAlertAction) -> Void in
-                self.dismiss(animated: true, completion: nil)
+                window?.rootViewController?.dismiss(animated: true, completion: nil)
             })
             bluetoothAlert.addAction(bluetoothAction)
-            self.present(bluetoothAlert, animated: true, completion: nil)
+            window?.rootViewController?.present(bluetoothAlert, animated: true, completion: nil)
         case .unknown:
             print("Bluetooth status is unknown")
         case .resetting:

--- a/Friendify/BLEService.swift
+++ b/Friendify/BLEService.swift
@@ -15,11 +15,12 @@ class BLEService: NSObject, CBCentralManagerDelegate, CBPeripheralDelegate {
     //centralManager = CBCentralManager(delegate: self, queue: nil)
     var centralManager: CBCentralManager!
     var blePeripheral: CBPeripheral!
-    @EnvironmentObject var peripherals: Peripherals
     
     //var connectedDevices = [CBPeripheral]()
     var RSSIs = [NSNumber]()
     var connectedPeripherals = [CBPeripheral]()
+    
+    @Published var devices = [Device]()
     
     func start() {
         print("Testing")
@@ -87,12 +88,14 @@ class BLEService: NSObject, CBCentralManagerDelegate, CBPeripheralDelegate {
         print("Device ID:")
         print(device.id)
         print("Device name:")
-        print(peripheral.name)
-        print(device.name ?? "N/A")
+        print(peripheral.name ?? "Unknown device")
+        print(device.name)
         print("Device info:")
         print(device.peripheral_class)
         
-        //peripherals.devices.append(device)
+        DispatchQueue.main.async {
+            self.devices.append(device)
+        }
     }
     
     func connectToDevice (peripheral: CBPeripheral) {

--- a/Friendify/Device.swift
+++ b/Friendify/Device.swift
@@ -19,7 +19,7 @@ class Peripheral: CBPeripheral, Identifiable {
 
 struct Device: Hashable, Identifiable {
     var id: UUID
-    var name: String!
+    var name: String
     var peripheral_class: CBPeripheral
 }
 
@@ -27,15 +27,9 @@ extension Device {
     
     init(peripheral: CBPeripheral) {
         id = peripheral.identifier
-        name = peripheral.name
+        name = peripheral.name ?? "Unknown device"
         peripheral_class = peripheral
     }
 }
 
 let foundDevices = [CBPeripheral]()
-
-final class Peripherals: ObservableObject {
-    @Published var devices = [Device]()
-}
-
-

--- a/Friendify/DeviceList.swift
+++ b/Friendify/DeviceList.swift
@@ -11,10 +11,10 @@ import CoreBluetooth
 import Combine
 
 struct DeviceList: View {
-    @EnvironmentObject var peripherals: Peripherals
+    @ObservedObject var viewModel: DeviceListViewModel
     
     var body: some View {
-        List(peripherals.devices) { device in
+        List(viewModel.devices) { device in
             Text(device.name)
             //DeviceRow(device: device)
         }
@@ -23,10 +23,7 @@ struct DeviceList: View {
 }
 
 struct DeviceList_Previews: PreviewProvider {
-    
-    static let peripherals = Peripherals()
-    
     static var previews: some View {
-        DeviceList().environmentObject(self.peripherals)
+        DeviceList(viewModel: DeviceListViewModel(bleService: BLEService()))
     }
 }

--- a/Friendify/DeviceListViewModel.swift
+++ b/Friendify/DeviceListViewModel.swift
@@ -1,0 +1,14 @@
+import Combine
+
+class DeviceListViewModel: ObservableObject {
+    private let bleService: BLEService
+    private var subscriptions = Set<AnyCancellable>()
+    
+    init(bleService: BLEService) {
+        self.bleService = bleService
+        
+        bleService.$devices.assign(to: \.devices, on: self).store(in: &subscriptions)
+    }
+    
+    @Published var devices = [Device]()
+}

--- a/Friendify/DeviceRow.swift
+++ b/Friendify/DeviceRow.swift
@@ -21,13 +21,13 @@ struct DeviceRow: View {
     }
 }
 
-struct DeviceRow_Previews: PreviewProvider {
-    static var peripherals = Peripherals()
-    static var previews: some View {
-        Group {
-            DeviceRow(device: peripherals.devices[0])
-            DeviceRow(device: peripherals.devices[1])
-        }
-        .previewLayout(.fixed(width: 300, height: 70))
-    }
-}
+//struct DeviceRow_Previews: PreviewProvider {
+//    static var peripherals = Peripherals()
+//    static var previews: some View {
+//        Group {
+//            DeviceRow(device: peripherals.devices[0])
+//            DeviceRow(device: peripherals.devices[1])
+//        }
+//        .previewLayout(.fixed(width: 300, height: 70))
+//    }
+//}

--- a/Friendify/Home.swift
+++ b/Friendify/Home.swift
@@ -12,25 +12,14 @@ import CoreBluetooth
 import Combine
 
 struct Home: View {
-    
-    @EnvironmentObject var peripherals: Peripherals
-    var ble = BLEService()
+    let viewModel: HomeViewModel
     
     var body: some View {
         VStack {
-            Button(action: {
-                self.ble.start()
-                //self.ble.startScan()
-            }) {
-                Text("Start Scanning")
-            }
-            Button(action: {
-                print("Hello World!")
-            }) {
-                Text("Hello World")
-            }
+            Button("Start scanning", action: viewModel.startButtonPressed)
+            Button("Hello World!", action: viewModel.helloWorldButtonPressed)
             //BluetoothScan(ble: ble)
-            DeviceList()
+            DeviceList(viewModel: DeviceListViewModel(bleService: viewModel.bleService))
         }
     }
 }
@@ -48,9 +37,7 @@ struct BluetoothScan: View {
  */
 
 struct Home_Previews: PreviewProvider {
-    
-    static let peripherals = Peripherals()
     static var previews: some View {
-        Home().environmentObject(self.peripherals)
+        Home(viewModel: HomeViewModel(bleService: BLEService()))
     }
 }

--- a/Friendify/Home.swift
+++ b/Friendify/Home.swift
@@ -14,12 +14,12 @@ import Combine
 struct Home: View {
     
     @EnvironmentObject var peripherals: Peripherals
-    var ble = BLECentralViewController()
+    var ble = BLEService()
     
     var body: some View {
         VStack {
             Button(action: {
-                self.ble.viewDidLoad()
+                self.ble.start()
                 //self.ble.startScan()
             }) {
                 Text("Start Scanning")

--- a/Friendify/HomeViewModel.swift
+++ b/Friendify/HomeViewModel.swift
@@ -1,0 +1,15 @@
+class HomeViewModel {
+    let bleService: BLEService
+    
+    init(bleService: BLEService) {
+        self.bleService = bleService
+    }
+    
+    func startButtonPressed() {
+        bleService.start()
+    }
+    
+    func helloWorldButtonPressed() {
+        print("Hello world!")
+    }
+}

--- a/Friendify/SceneDelegate.swift
+++ b/Friendify/SceneDelegate.swift
@@ -12,25 +12,25 @@ import SwiftUI
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
     var window: UIWindow?
-    var peripherals = Peripherals()
-
 
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
         // Use this method to optionally configure and attach the UIWindow `window` to the provided UIWindowScene `scene`.
         // If using a storyboard, the `window` property will automatically be initialized and attached to the scene.
         // This delegate does not imply the connecting scene or session are new (see `application:configurationForConnectingSceneSession` instead).
 
+        let home = Home(viewModel: HomeViewModel(bleService: BLEService()))
+        
         // Get the managed object context from the shared persistent container.
         let context = (UIApplication.shared.delegate as! AppDelegate).persistentContainer.viewContext
 
         // Create the SwiftUI view and set the context as the value for the managedObjectContext environment keyPath.
         // Add `@Environment(\.managedObjectContext)` in the views that will need the context.
-        _ = Home().environment(\.managedObjectContext, context)
+        _ = home.environment(\.managedObjectContext, context)
 
         // Use a UIHostingController as window root view controller.
         if let windowScene = scene as? UIWindowScene {
             let window = UIWindow(windowScene: windowScene)
-            window.rootViewController = UIHostingController(rootView: Home().environmentObject(Peripherals()))
+            window.rootViewController = UIHostingController(rootView: home)
             self.window = window
             window.makeKeyAndVisible()
         }


### PR DESCRIPTION
- Renamed `BLEController` to `BLEService` and made it into a basic object instead of a view controller
- Added view models for `Home` and `DeviceList` for easier separation of concerns
- Store the devices in `BLEService` instead of an environment object and pass that service to everyone who needs it